### PR TITLE
renamed Azure Cloud Storage to Azure Blob

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM sonatype/nexus3:3.19.1
 
-COPY target/nexus-blobstore-azure-cloud-0.4.0-SNAPSHOT-bundle.kar /opt/sonatype/nexus/deploy
+COPY target/nexus-blobstore-azure-blob-0.4.0-SNAPSHOT-bundle.kar /opt/sonatype/nexus/deploy

--- a/README.md
+++ b/README.md
@@ -12,14 +12,16 @@
     Eclipse Foundation. All other trademarks are the property of their respective owners.
 
 -->
-Nexus Repository Azure Cloud Storage Blobstore
+Nexus Repository Azure Blob Blobstore
 ==============================
 
 [![Join the chat at https://gitter.im/sonatype/nexus-developers](https://badges.gitter.im/sonatype/nexus-developers.svg)](https://gitter.im/sonatype/nexus-developers?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-This project adds [Azure Cloud Object Storage](https://cloud.Azure.com/storage/) backed blob stores to Sonatype Nexus 
-Repository 3.16 and later.  It allows Nexus Repository to store the components and assets in Azure Cloud instead of a
-local filesystem.
+This project adds [Azure Blob object storage](https://docs.microsoft.com/en-us/azure/storage/blobs/) backed
+[blob stores](https://help.sonatype.com/repomanager3/high-availability/configuring-blob-stores) to Sonatype Nexus 
+Repository 3.16 and later.  It allows Nexus Repository to store the components and assets in Azure Blob instead of a
+local Azure Disk filesystem or Azure File SMB share
+(see [Azure Storage Documentation](https://docs.microsoft.com/en-us/azure/storage/common/storage-decide-blobs-files-disks)).
 
 Contribution Guidelines
 -----------------------
@@ -33,44 +35,44 @@ Requirements
 
 Building
 --------
-To build the project and generate the bundle use Maven:
+To build the project and generate the bundle, use Maven:
 
     mvn clean package
 
-Creating Docker Image bundled with Azure Storage Plugin
+Creating Docker Image bundled with Azure Blob Plugin
 -------------------------------------------------------
-To create a docker image and run it with the Azaure Storage plugin baked in, run the following commands: 
+To create a docker image and run it with the Azure Blob plugin baked in, run the following commands: 
 
     mvn clean package
-    docker build -t nexus3_azure .
-    docker run -d -p 8081:8081 --name nexus3azure -v nexus3azure-data:/nexus-data nxrm_azure:latest
+    docker build -t nexus3_azure-blob .
+    docker run -d -p 8081:8081 --name nexus3azure-blob -v nexus3azure-data:/nexus-data nxrm_azure:latest
     
 
 Integration Tests
 -----------------
-To run integration commands active the `it` profile and include the system properties `nxrm.azure.accountName` and 
+To run integration commands, active the `it` profile and include the system properties `nxrm.azure.accountName` and 
 `Dnxrm.azure.accountKey`. Integration tests will create temporary storage containers and tests should cleanup when 
-complete. If you're running tests often check your storage account because it is likely that some containers may be left
+complete. If you're running tests often, check your storage account because it is likely that some containers may be left
 behind and not properly cleanup up by the tests. 
 
      mvn clean install -P it -Dnxrm.azure.accountName=<accountName> -Dnxrm.azure.accountKey=<accountKey>
 
 
-Azure Cloud Storage Permissions
+Azure Blob Storage Permissions
 --------------------------------
 TODO
 
-Azure Cloud Storage Authentication
+Azure Blob Storage Authentication
 -----------------------------------
 TODO
 
 
 Installation
 ------------
-While nexus is stopped, copy target/nexus-blobstore-azure-cloud-0.4.0-SNAPSHOT-shaded.jar in the deploy folder in your
-nexus 3 distribution. Start nexus and the plugin will be installed.
+While Nexus Repository is stopped, copy target/nexus-blobstore-azure-cloud-0.4.0-SNAPSHOT-shaded.jar in the deploy folder in your
+Nexus Repository 3 distribution. Start Nexus Repository and the plugin will be installed.
 
-Log in as admin and create a new blobstore, selecting 'Azure Cloud Storage' as the type.
+Log in as admin and create a new blobstore, selecting 'Azure Blob Storage' as the type.
 
 The Fine Print
 --------------
@@ -82,7 +84,7 @@ Remember:
 
 * Use this contribution at the risk tolerance that you have. 
 * There are some incomplete features and known issues.
-* Do NOT file Sonatype support tickets related to Azure Cloud support
+* Do NOT file Sonatype support tickets related to Azure Blob support
 * DO file issues here on GitHub, so that the community can pitch in
 
 Phew, that was easier than I thought. Last but not least of all:

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <version>3.19.1-01</version>
   </parent>
 
-  <artifactId>nexus-blobstore-azure-cloud</artifactId>
+  <artifactId>nexus-blobstore-azure-blob</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
   <inceptionYear>2019</inceptionYear>
   <version>0.4.0-SNAPSHOT</version>

--- a/src/main/java/org/sonatype/nexus/blobstore/azure/internal/AzureBlobStore.java
+++ b/src/main/java/org/sonatype/nexus/blobstore/azure/internal/AzureBlobStore.java
@@ -62,13 +62,13 @@ import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.St
 import static org.sonatype.nexus.common.stateguard.StateGuardLifecycleSupport.State.STOPPED;
 
 /**
- * Azure Cloud Storage backed {@link BlobStore}.
+ * Azure Blob Cloud Storage backed {@link BlobStore}.
  */
 @Named(AzureBlobStore.TYPE)
 public class AzureBlobStore
     extends BlobStoreSupport<AttributesLocation>
 {
-  public static final String TYPE = "Azure Cloud Storage";
+  public static final String TYPE = "Azure Blob Storage";
 
   public static final String CONFIG_KEY = TYPE.toLowerCase();
 


### PR DESCRIPTION
(brief, plain english overview of your changes here)

This pull request makes the following changes:
* renamed Azure Cloud Storage to Azure Blob to match Azure naming

While merging, it would be useful to update the description of the GitHub project, and eventually to rename it to "nexus-blobstore-azure-blob" or "nexus-blobstore-azure"